### PR TITLE
Support spaces in issue types (e.g. Tech Debt)

### DIFF
--- a/src/ghIssuesHandling.js
+++ b/src/ghIssuesHandling.js
@@ -6,7 +6,7 @@ function sliceGHInput( rawText ) {
     let currentParameters = rawText
     let snippet           = null
     
-    while( ( snippet = /(?:,\s?)*(?<paramValue>[a-zA-Z1-9-]+)/g.exec( currentParameters ) ) ) {
+    while( ( snippet = /(?:,\s?)*(?<paramValue>[a-zA-Z1-9-\s]+)/g.exec( currentParameters ) ) ) {
         if( snippet.groups.paramValue ) {
             slicesResult.push( snippet.groups.paramValue )
             currentParameters = currentParameters.replace( snippet.groups.paramValue, '' )

--- a/src/jiraSubtaskHandling.js
+++ b/src/jiraSubtaskHandling.js
@@ -7,7 +7,7 @@ function sliceGHInput( rawText ) {
 	let currentParameters = rawText
 	let snippet           = null
 	
-	while( ( snippet = /(?:,\s?)*(?<paramValue>[a-zA-Z1-9-]+)/g.exec( currentParameters ) ) ) {
+	while( ( snippet = /(?:,\s?)*(?<paramValue>[a-zA-Z1-9-\s]+)/g.exec( currentParameters ) ) ) {
 		if( snippet.groups.paramValue ) {
 			slicesResult.push( snippet.groups.paramValue )
 			currentParameters = currentParameters.replace( snippet.groups.paramValue, '' )


### PR DESCRIPTION
With the current regex, if an issue type has a space character, sliceGhInput will only detect the first part of the input e.g. 
"Tech Debt" -> Tech
As u see below 2 matches instead of one with old regex:
<img width="607" alt="image" src="https://user-images.githubusercontent.com/10706173/81125371-f2d6e700-8f05-11ea-8ffe-76d7250c678c.png">

The updated regex will include spaces as allowed characters resulting in:
"tech Debt" -> Tech Debt
Notice One match with the updated regex including \s
<img width="506" alt="image" src="https://user-images.githubusercontent.com/10706173/81125426-18fc8700-8f06-11ea-8fcd-4b5b955a8183.png">

